### PR TITLE
ローカルプッシュでリマインドできるようになりました

### DIFF
--- a/memo2/AppDelegate.swift
+++ b/memo2/AppDelegate.swift
@@ -7,14 +7,15 @@
 //
 
 import UIKit
+import UserNotifications
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
-        return true
-    }
+//    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+//        // Override point for customization after application launch.
+//        return true
+//    }
 
     // MARK: UISceneSession Lifecycle
 
@@ -29,6 +30,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
+    
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+           //push通知許可の要求
+           UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
+
+           UNUserNotificationCenter.current().requestAuthorization(options:
+                   [.alert, .sound, .badge]) { (granted, error) in
+           }
+           return true
+       }
     
 }
 

--- a/memo2/ViewController.swift
+++ b/memo2/ViewController.swift
@@ -94,6 +94,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     
     
     @IBAction func tapSubmitButton(_ sender: Any) {
+        //local push
         guard let remindDate = self.localPushDate else{
             applyMemo()
 //            print("applyWithoutRemind")
@@ -132,13 +133,14 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        applyMemo()
+        tapSubmitButton(UIButton.self)
+//        applyMemo()
         return true
     }
     
     
     func applyMemo() {
-        if editMemoField.text == nil {
+        if editMemoField.text == "" {
             return
         }
         

--- a/memo2/ViewController.swift
+++ b/memo2/ViewController.swift
@@ -94,14 +94,17 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     
     
     @IBAction func tapSubmitButton(_ sender: Any) {
+        print("ローカルプッシュ通知1件セット完了")
+        setNotification(date: self.localPushDate! as Date, memoField: editMemoField.text!)
+        print("setNotification")
+        
         applyMemo()
         //ブッシュ通知
 //        if let self.pushDate = self.localPushDate{
 //            print("ローカルプッシュ通知1件セット完了")
 //            setNotification(date: pushDate)
 //        }
-        print("ローカルプッシュ通知1件セット完了")
-//        setNotification(date: self.localPushDate!)
+
 
     }
     
@@ -149,7 +152,6 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         
         let defaults = UserDefaults.standard
         defaults.set(memoList, forKey: "MEMO_LIST")
-        
         editMemoField.text = ""
         editRow = unselectedRow
         memoListView.reloadData()
@@ -174,31 +176,31 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
 
     }
     
-//    func setNotification(date: Date) {
-//        //通知日時の設定
-//        var trigger: UNNotificationTrigger
-//        //noticficationtimeにdatepickerで取得した値をset
-//        let notificationTime = Calendar.current.dateComponents(in: TimeZone.current, from: date)
-//        //現在時刻の取得
-//        let now = Date()
-//        //変数setDateに取得日時をDatecomponens型で代入
-//        let setDate = DateComponents(calendar: .current, year: notificationTime.year, month: notificationTime.month, day: notificationTime.day, hour: notificationTime.hour, minute: notificationTime.minute,second: notificationTime.second).date!
-//        //変数secondsに現在時刻と通知日時の差分の秒数を代入
-//        let seconds = setDate.seconds(from: now)
-//        //triggerに現在時刻から〇〇秒後の通知実行時間をset
-//        trigger = UNTimeIntervalNotificationTrigger(timeInterval: TimeInterval(seconds), repeats: false)
-//        //通知内容の設定
-//        let content = UNMutableNotificationContent()
-//        content.title = "title text"
-//        content.body = "body text"
-//        content.sound = .default
-//        //ユニークIDの設定
-//        let identifier = NSUUID().uuidString
-//        //登録用リクエストの設定
-//        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
-//        //通知をセット
-//        UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
-//    }
+    func setNotification(date: Date, memoField: String) {
+        //通知日時の設定
+        var trigger: UNNotificationTrigger
+        //noticficationtimeにdatepickerで取得した値をset
+        let notificationTime = Calendar.current.dateComponents(in: TimeZone.current, from: date)
+        //現在時刻の取得
+        let now = Date()
+        //変数setDateに取得日時をDatecomponens型で代入
+        let setDate = DateComponents(calendar: .current, year: notificationTime.year, month: notificationTime.month, day: notificationTime.day, hour: notificationTime.hour, minute: notificationTime.minute,second: notificationTime.second).date!
+        //変数secondsに現在時刻と通知日時の差分の秒数を代入
+        let seconds = setDate.seconds(from: now)
+        //triggerに現在時刻から〇〇秒後の通知実行時間をset
+        trigger = UNTimeIntervalNotificationTrigger(timeInterval: TimeInterval(seconds), repeats: false)
+        //通知内容の設定
+        let content = UNMutableNotificationContent()
+        content.title = "title"
+        content.body = memoField
+        content.sound = .default
+        //ユニークIDの設定
+        let identifier = NSUUID().uuidString
+        //登録用リクエストの設定
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+        //通知をセット
+        UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+    }
 
     
 }

--- a/memo2/ViewController.swift
+++ b/memo2/ViewController.swift
@@ -94,17 +94,15 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     
     
     @IBAction func tapSubmitButton(_ sender: Any) {
-        print("ローカルプッシュ通知1件セット完了")
-        setNotification(date: self.localPushDate! as Date, memoField: editMemoField.text!)
-        print("setNotification")
+        guard let remindDate = self.localPushDate else{
+            applyMemo()
+//            print("applyWithoutRemind")
+            return
+        }
+        setNotification(date: remindDate as Date, memoField: editMemoField.text!)
         
         applyMemo()
-        //ブッシュ通知
-//        if let self.pushDate = self.localPushDate{
-//            print("ローカルプッシュ通知1件セット完了")
-//            setNotification(date: pushDate)
-//        }
-
+//        print("applyMemo")
 
     }
     
@@ -164,8 +162,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         // 日付のフォーマット
         let formatter = DateFormatter()
         self.localPushDate = datePicker.date
-        print("localPushDate")
-        print(self.localPushDate)
+//        print("localPushDate")
+//        print(self.localPushDate)
         
         //"yyyy年MM月dd日"を"yyyy/MM/dd"したりして出力の仕方を好きに変更できるよ
         formatter.dateFormat = "MM/dd/HH:mm"

--- a/memo2/ViewController.swift
+++ b/memo2/ViewController.swift
@@ -8,7 +8,15 @@
 //
 
 import UIKit
+import UserNotifications
+
 private let unselectedRow = -1
+//引数で指定した日付との差分の秒数を返すextension
+extension Date {
+    func seconds(from date: Date) -> Int {
+        return Calendar.current.dateComponents([.second], from: date, to: self).second ?? 0
+    }
+}
 
 class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, UITextFieldDelegate {
     
@@ -21,6 +29,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     let gloVar = GlobalVar.shared
     var memoList: [String] = []
     var editRow: Int = unselectedRow
+    var datePicker: UIDatePicker = UIDatePicker()
+    var localPushDate: Date?
     
     
     override func viewDidLoad() {
@@ -35,6 +45,22 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             memoList = loadedMemoList as! [String]
         }
         self.tagText.text = gloVar.selectTag
+        
+        // ピッカー設定
+        datePicker.datePickerMode = UIDatePicker.Mode.dateAndTime
+        datePicker.timeZone = NSTimeZone.local
+        datePicker.locale = Locale.current
+        reminderText.inputView = datePicker
+
+        // 決定バーの生成
+        let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: 35))
+        let spacelItem = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
+        let doneItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(done))
+        toolbar.setItems([spacelItem, doneItem], animated: true)
+
+        // インプットビュー設定(紐づいているUITextfieldへ代入)
+        reminderText.inputView = datePicker
+        reminderText.inputAccessoryView = toolbar
     }
     
     
@@ -69,6 +95,14 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     
     @IBAction func tapSubmitButton(_ sender: Any) {
         applyMemo()
+        //ブッシュ通知
+//        if let self.pushDate = self.localPushDate{
+//            print("ローカルプッシュ通知1件セット完了")
+//            setNotification(date: pushDate)
+//        }
+        print("ローカルプッシュ通知1件セット完了")
+//        setNotification(date: self.localPushDate!)
+
     }
     
     
@@ -120,5 +154,51 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         editRow = unselectedRow
         memoListView.reloadData()
     }
+    
+    // UIDatePickerのDoneを押したら日時設定
+    @objc func done() {
+        reminderText.endEditing(true)
+
+        // 日付のフォーマット
+        let formatter = DateFormatter()
+        self.localPushDate = datePicker.date
+        print("localPushDate")
+        print(self.localPushDate)
+        
+        //"yyyy年MM月dd日"を"yyyy/MM/dd"したりして出力の仕方を好きに変更できるよ
+        formatter.dateFormat = "MM/dd/HH:mm"
+
+        //(from: datePicker.date))を指定してあげることで
+        //datePickerで指定した日付が表示される
+        reminderText.text = "\(formatter.string(from: datePicker.date))"
+
+    }
+    
+//    func setNotification(date: Date) {
+//        //通知日時の設定
+//        var trigger: UNNotificationTrigger
+//        //noticficationtimeにdatepickerで取得した値をset
+//        let notificationTime = Calendar.current.dateComponents(in: TimeZone.current, from: date)
+//        //現在時刻の取得
+//        let now = Date()
+//        //変数setDateに取得日時をDatecomponens型で代入
+//        let setDate = DateComponents(calendar: .current, year: notificationTime.year, month: notificationTime.month, day: notificationTime.day, hour: notificationTime.hour, minute: notificationTime.minute,second: notificationTime.second).date!
+//        //変数secondsに現在時刻と通知日時の差分の秒数を代入
+//        let seconds = setDate.seconds(from: now)
+//        //triggerに現在時刻から〇〇秒後の通知実行時間をset
+//        trigger = UNTimeIntervalNotificationTrigger(timeInterval: TimeInterval(seconds), repeats: false)
+//        //通知内容の設定
+//        let content = UNMutableNotificationContent()
+//        content.title = "title text"
+//        content.body = "body text"
+//        content.sound = .default
+//        //ユニークIDの設定
+//        let identifier = NSUUID().uuidString
+//        //登録用リクエストの設定
+//        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+//        //通知をセット
+//        UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+//    }
+
     
 }


### PR DESCRIPTION
- テキストフィールドを選択すると、DatePikerのダイヤルが表示され、Doneでリマインド日時を追加
- テキストフィールドの中身が空の時はリマインドしない
- 確定orReturnでメモ（リマインダ込み）追加
- ついでに、空のメモは追加できないようになりました。